### PR TITLE
Fixed data grid graph canvas getting cut off

### DIFF
--- a/src/components/DataModelGraph/DataGridGraph.vue
+++ b/src/components/DataModelGraph/DataGridGraph.vue
@@ -2056,7 +2056,10 @@ export default {
 @import '@/assets/css/_variables.scss';
 
 .hiddenCanvas {
-  //display: none;
+  position: absolute;
+  left: 0;
+  top: 0;
+  z-index: -1;
 }
 
 .data-model-graph {

--- a/src/components/GraphBrowser/GraphBrowser.vue
+++ b/src/components/GraphBrowser/GraphBrowser.vue
@@ -172,8 +172,6 @@ import DataGridGraph from '@/components/DataModelGraph/DataGridGraph.vue'
   .graph-browser {
     height: 100%;
     margin: 0px;
-    height: calc(100vh - 130px);
-    overflow: hidden;
     position: relative;
   }
   .models-list-wrap {

--- a/src/components/OrgActivity/OrgActivity.vue
+++ b/src/components/OrgActivity/OrgActivity.vue
@@ -183,7 +183,7 @@ export default {
      */
     getDatasetUsersUrl: function() {
       const datasetId = this.datasetId
-      const apiKey = this.userToken()
+      const apiKey = this.userToken
       return  `https//:api.pennsieve.io/datasets/${datasetId}/collaborators/users?api_key=${apiKey}`
     },
 


### PR DESCRIPTION
Fixed the datagrid canvas getting cut off on the bottom and positioned the hidden canvas directly behind the visible one