### PR TITLE
Allow user to select multiple linking targets

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lint": "vue-cli-service lint",
     "dev-setup": "mkdir -p dist_electron/protos && cp -pr src/utils/pennsieve/protos/agent.proto dist_electron/protos",
     "electron:build": "vue-cli-service electron:build",
-    "electron:serve": "yarn dev-setup && vue-cli-service electron:serve",
+    "electron:serve": "vue-cli-service electron:serve",
     "postinstall": "electron-builder install-app-deps",
     "postuninstall": "electron-builder install-app-deps"
   },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lint": "vue-cli-service lint",
     "dev-setup": "mkdir -p dist_electron/protos && cp -pr src/utils/pennsieve/protos/agent.proto dist_electron/protos",
     "electron:build": "vue-cli-service electron:build",
-    "electron:serve": "vue-cli-service electron:serve",
+    "electron:serve": "yarn dev-setup && vue-cli-service electron:serve",
     "postinstall": "electron-builder install-app-deps",
     "postuninstall": "electron-builder install-app-deps"
   },

--- a/src/app.vue
+++ b/src/app.vue
@@ -23,12 +23,12 @@ export default {
     ...mapGetters(['selectedStudy', 'searchModalVisible'])
   },
   methods: {
-    ...mapActions(['setLinkingTarget']),
+    ...mapActions(['setLinkingTargets']),
   },
   watch: {
     async selectedStudy() {
       // Clear the linking target when we change what study is selected
-      this.setLinkingTarget({})
+      this.setLinkingTargets([])
     }
   }
 }

--- a/src/assets/css/index.scss
+++ b/src/assets/css/index.scss
@@ -2,7 +2,7 @@
 @import './_svg-icon';
 
 html {
-  min-width: fit-content;
+  width: 100%;
   font-family: $system-font;
 }
 body {

--- a/src/components/DataModelGraph/DataGridGraph.vue
+++ b/src/components/DataModelGraph/DataGridGraph.vue
@@ -162,7 +162,7 @@ export default {
       'shadedParticipants',
       'selectedStudyName'
     ]),
-    ...mapGetters(['userToken','triggerForClearing','linkingTarget']),
+    ...mapGetters(['userToken','triggerForClearing','linkingTargets']),
     /*
     onFilterAdd: function() {
       this.filterStatus = searchModalSearch.filters;
@@ -324,7 +324,7 @@ export default {
 
   methods: {
     //will not use these map actions since all data will be within component
-    ...mapActions(['updateSearchModalVisible', 'updateSearchModalSearch','setAllParticipants','setAllVisits','setAllSamples','setShadedParticipants','setShadedVisits','setShadedSamples','setShadedFiles','setLinkingTarget','updatefilterApplicationCount']), //include set all files potentially
+    ...mapActions(['updateSearchModalVisible', 'updateSearchModalSearch','setAllParticipants','setAllVisits','setAllSamples','setShadedParticipants','setShadedVisits','setShadedSamples','setShadedFiles','setLinkingTargets','updatefilterApplicationCount']), //include set all files potentially
 
     setupMouseOver: function() {
       const vm = this
@@ -822,9 +822,9 @@ export default {
                 // TODO: figure this out ~ this will be the target of linking a file (on Uploads page)
                   console.log(`visit_to_be_linked:`)
                   console.log(nodeData.details)
-                  console.log(this.linkingTarget)
-                  this.setLinkingTarget(nodeData.details)
-                  console.log(this.linkingTarget)
+                  console.log(this.linkingTargets)
+                  //this.setLinkingTargets(nodeData.details)
+                  console.log(this.linkingTargets)
                 //}
                 fillstyle ="#0049d1"
                 // eslint-disable-next-line
@@ -854,8 +854,8 @@ export default {
               // TODO: figure this out ~ this will be the target of linking a file (on Uploads page)
                   console.log('experiment to be linked:')
                   console.log(nodeData.details)
-                  this.setLinkingTarget(nodeData.details)
-                  console.log(this.linkingTarget)
+                  this.setLinkingTargets(nodeData.details)
+                  console.log(this.linkingTargets)
                 //}
 
                 fillstyle ="#f0cc00"

--- a/src/components/SearchAllData/SearchAllData.vue
+++ b/src/components/SearchAllData/SearchAllData.vue
@@ -155,7 +155,7 @@ export default {
      * Resets table search params for pagination
      */
     resetSearchParams: function() {
-      const newSearch = mergeRight(this.searchModalSearch, { limit: 25, offset: 0 })
+      const newSearch = mergeRight(this.searchModalSearch, { limit: 10, offset: 0 })
       this.updateSearchModalSearch(newSearch)
       this.$nextTick(async () => {
         await this.$refs.searchResults.fetchRecords()

--- a/src/components/SearchAllData/SearchResults/RecordsTable/RecordsTable.vue
+++ b/src/components/SearchAllData/SearchResults/RecordsTable/RecordsTable.vue
@@ -154,6 +154,7 @@ export default {
     }
   },
 
+  methods: {
     /**
      * Callback from sort change
      * Set new sort order and property
@@ -176,6 +177,7 @@ export default {
      * Handle table selection change
      * @param {Array} selection
      */
+    // eslint-disable-next-line no-unused-vars
      handleTableSelectionChange: function(selection, row) {
       this.$emit('selection-changed', selection)
     },

--- a/src/components/SearchAllData/SearchResults/RecordsTable/RecordsTable.vue
+++ b/src/components/SearchAllData/SearchResults/RecordsTable/RecordsTable.vue
@@ -5,6 +5,7 @@
       :border="true"
       :data="data"
       @select="handleTableSelectionChange"
+      @select-all="selectAll"
       @sort-change="onSortChange"
     >
       <el-table-column
@@ -193,6 +194,7 @@ export default {
       } else {
         this.deleteRows(this.data)
       }
+      this.$emit('selection-changed', this.selectedItems)
     },
     // Add the check 
     addRows (rows) {

--- a/src/components/SearchAllData/SearchResults/RecordsTable/RecordsTable.vue
+++ b/src/components/SearchAllData/SearchResults/RecordsTable/RecordsTable.vue
@@ -4,9 +4,15 @@
       ref="table"
       :border="true"
       :data="data"
+      @select="handleTableSelectionChange"
       @sort-change="onSortChange"
-      @row-click="onRowClick"
     >
+      <el-table-column
+        type="selection"
+        align="center"
+        fixed
+        width="50"
+      />
       <el-table-column
         v-for="heading in headings"
         :key="heading.name"
@@ -68,9 +74,7 @@
 </template>
 
 <script>
-import {
-  propOr
-} from 'ramda'
+import { propOr } from 'ramda'
 
 import TableMenu from '@/components/TableMenu/TableMenu.vue'
 
@@ -125,28 +129,30 @@ export default {
       default: () => {
         return {}
       }
-    }
+    },
+    recordType: {
+      type: String,
+      default: ''
+    },
   },
 
   data () {
     return {
-      activeRow: {},
-      selection: [],
-      sortOrders: ['ascending', 'descending'],
-      checkAll: false
     }
   },
 
-  methods: {
-    /**
-     * Action when clicking a row
-     */
-    onRowClick: function(row, column) {
-     const columnProperty = propOr('', 'property', column)
-     if (columnProperty !== undefined) {
-       this.$emit('navigate-to-record', row)
-     }
-    },
+  computed: {
+    // return the name of the property of the object that we should be using to identify a row by (the properties available differ between visits, samples, and experiments)
+    rowKeyProp() {
+      if (this.recordType == 'Visits') {
+        return 'visit_event'
+      }
+      if (this.recordType == 'Samples') {
+        return 'study_sample_id'
+      }
+      return ''
+    }
+  },
 
     /**
      * Callback from sort change
@@ -165,7 +171,14 @@ export default {
         ascending,
         orderDirection
       })
-    }
+    },
+    /**
+     * Handle table selection change
+     * @param {Array} selection
+     */
+     handleTableSelectionChange: function(selection, row) {
+      this.$emit('selection-changed', selection)
+    },
   }
 }
 </script>
@@ -223,5 +236,9 @@ export default {
 .record-actions-wrap {
   display: flex;
   justify-content: flex-end;
+}
+
+.el-table--border .el-table__cell:first-child .cell {
+  padding-left: unset;
 }
 </style>

--- a/src/components/SearchAllData/SearchResults/SearchResults.vue
+++ b/src/components/SearchAllData/SearchResults/SearchResults.vue
@@ -60,7 +60,6 @@
             :is-sortable="isRecordsSortable"
             :table-search-params="tableSearchParams"
             @linking-targets-changed="onLinkingTargetsChanged"
-            @selection-changed="onSelectionChanged"
             @sort="$emit('sort', $event)"
           />
         </div>

--- a/src/components/SearchAllData/SearchResults/SearchResults.vue
+++ b/src/components/SearchAllData/SearchResults/SearchResults.vue
@@ -185,7 +185,6 @@ export default {
         && this.isLoadingRecords === false
     },
     recordType: function() {
-      console.log("RECORD TYPE", this.selectedButton)
       return this.selectedButton
     }
   },

--- a/src/components/SearchAllData/SearchResults/SearchResults.vue
+++ b/src/components/SearchAllData/SearchResults/SearchResults.vue
@@ -11,7 +11,7 @@
         size="medium"
       >
         <el-radio-button
-          label="Experiments"
+          label="Samples"
         />
         <el-radio-button
           label="Visits"
@@ -52,13 +52,15 @@
           <records-table
             class="search-results-records-table"
             :data="recordResults"
+            :record-type="recordType"
             :headings="recordHeadings"
             :show-menu-column="showMenuColumn"
             :search-all-data-menu="true"
             :search-all-data-records="true"
             :is-sortable="isRecordsSortable"
             :table-search-params="tableSearchParams"
-            @navigate-to-record="navigateToRecord"
+            @linking-targets-changed="onLinkingTargetsChanged"
+            @selection-changed="onSelectionChanged"
             @sort="$emit('sort', $event)"
           />
         </div>
@@ -179,6 +181,10 @@ export default {
     showResultsState: function() {
       return this.noResultsFound === false
         && this.isLoadingRecords === false
+    },
+    recordType: function() {
+      console.log("RECORD TYPE", this.selectedButton)
+      return this.selectedButton
     }
   },
   watch: {
@@ -199,7 +205,7 @@ export default {
     },
   },
   methods: {
-    ...mapActions(['updateSearchModalVisible', 'updateSearchModalSearch', 'setLinkingTarget']),
+    ...mapActions(['updateSearchModalVisible', 'updateSearchModalSearch', 'setLinkingTargets']),
     /**
      * Fetches record search results
      */
@@ -236,11 +242,7 @@ export default {
       this.updateSearchModalSearch(newSearch)
       await this.fetchRecords()
     },
-    /**
-     * Navigate to records details route
-     * @param {Object} record
-     */
-    navigateToRecord: function(record) {
+    onLinkingTargetsChanged: function(records) {
       /*
       // Set the target when record is clicked
       var vis_arr_len = this.shadedVisits;
@@ -248,10 +250,10 @@ export default {
       //if a single selection has been made for sample or visit via user click, then they need to unselect it before proceeding
       if (vis_arr_len.length == 1 || samp_arr_len.length == 1){
         var to_be_linked = this.selectedRecord.details.id //CONFIRM THIS IS THE DATA WE ARE INTERESTED IN!
-        this.setLinkingTarget(to_be_linked)
+        this.setLinkingTargets(to_be_linked)
       }
       */
-      this.setLinkingTarget(record)
+      this.setLinkingTargets(records)
       this.updateSearchModalVisible(false)
     },
   }

--- a/src/components/SearchAllData/SearchResults/SearchResults.vue
+++ b/src/components/SearchAllData/SearchResults/SearchResults.vue
@@ -1,4 +1,3 @@
-
 <template>
   <div class="search-results">
     <div
@@ -52,6 +51,7 @@
           <records-table
             class="search-results-records-table"
             :data="recordResults"
+            :selected-rows="selections"
             :record-type="recordType"
             :headings="recordHeadings"
             :show-menu-column="showMenuColumn"
@@ -59,6 +59,7 @@
             :search-all-data-records="true"
             :is-sortable="isRecordsSortable"
             :table-search-params="tableSearchParams"
+            @selection-changed="onSelectionChanged"
             @linking-targets-changed="onLinkingTargetsChanged"
             @sort="$emit('sort', $event)"
           />
@@ -138,6 +139,7 @@ export default {
   },
   data() {
     return {
+      selections: [],
       recordResults: [],
       recordHeadings: [],
       selectedButton: 'Visits',
@@ -255,6 +257,9 @@ export default {
       this.setLinkingTargets(records)
       this.updateSearchModalVisible(false)
     },
+    onSelectionChanged: function(rows) {
+      this.selections = rows
+    }
   }
 }
 </script>

--- a/src/components/SearchAllData/SearchResults/SearchResults.vue
+++ b/src/components/SearchAllData/SearchResults/SearchResults.vue
@@ -64,20 +64,19 @@
           />
         </div>
       </div>
-      <bf-button class="linking-targets-button" @click="updateLinkingTargets" :disabled="!showResultsState">Set Linking Targets</bf-button>
+      <bf-button class="close-button" @click="onClose" :disabled="!showResultsState">Close</bf-button>
     </div>
   </div>
 </template>
 
 <script>
-/* eslint-disable */
 import { mapActions, mapGetters, mapState } from 'vuex'
 import RecordsTable from './RecordsTable/RecordsTable.vue'
 import PaginationPageMenu from '@/components/shared/PaginationPageMenu/PaginationPageMenu.vue'
 import Request from '@/mixins/request/index'
 import FormatDate from '@/mixins/format-date'
 import BfButton from '@/components/shared/BfButton.vue'
-import { mergeRight } from 'ramda'
+import { mergeRight, clone } from 'ramda'
 import {
   fetchFilteredVisitsMetadataRelatedToStudy,
   fetchFilteredSamplesMetadataRelatedToStudy,
@@ -153,7 +152,7 @@ export default {
     }
   },
   computed: {
-    ...mapState(['selectedStudy', 'searchModalSearch', 'linkingTargets']),
+    ...mapState(['selectedStudy', 'searchModalSearch', 'linkingTargets', 'searchModalVisible']),
     ...mapGetters(['userToken']),
     /**
      * Returns the current page postion for files table in pagination ticker
@@ -191,6 +190,12 @@ export default {
     }
   },
   watch: {
+    searchModalVisible(visible){
+      // Whenever the dialog is closed set the linking targets (a user does not have to explicty click a submit button to set the targets)
+      if (!visible) {
+        this.setLinkingTargets(clone(this.selections))
+      }
+    },
     /**
      * Watches for button change in order
      * to reset pagination
@@ -251,8 +256,7 @@ export default {
       this.updateSearchModalSearch(newSearch)
       await this.fetchRecords()
     },
-    updateLinkingTargets: function() {
-      this.setLinkingTargets(this.selections)
+    onClose: function() {
       this.updateSearchModalVisible(false)
     },
     onSelectionChanged: function(rows) {
@@ -338,7 +342,7 @@ h3 {
 .download-icon {
   margin-top: -4px;
 }
-.linking-targets-button {
+.close-button {
   float: right;
   margin-top: 1rem;
 }

--- a/src/components/SearchAllData/SearchResults/SearchResults.vue
+++ b/src/components/SearchAllData/SearchResults/SearchResults.vue
@@ -60,11 +60,11 @@
             :is-sortable="isRecordsSortable"
             :table-search-params="tableSearchParams"
             @selection-changed="onSelectionChanged"
-            @linking-targets-changed="onLinkingTargetsChanged"
             @sort="$emit('sort', $event)"
           />
         </div>
       </div>
+      <bf-button class="linking-targets-button" @click="updateLinkingTargets" :disabled="!showResultsState">Set Linking Targets</bf-button>
     </div>
   </div>
 </template>
@@ -76,6 +76,7 @@ import RecordsTable from './RecordsTable/RecordsTable.vue'
 import PaginationPageMenu from '@/components/shared/PaginationPageMenu/PaginationPageMenu.vue'
 import Request from '@/mixins/request/index'
 import FormatDate from '@/mixins/format-date'
+import BfButton from '@/components/shared/BfButton.vue'
 import { mergeRight } from 'ramda'
 import {
   fetchFilteredVisitsMetadataRelatedToStudy,
@@ -86,7 +87,8 @@ export default {
   name: 'SearchResults',
   components: {
     RecordsTable,
-    PaginationPageMenu
+    PaginationPageMenu,
+    BfButton
   },
   mixins: [Request, FormatDate],
   props: {
@@ -151,7 +153,7 @@ export default {
     }
   },
   computed: {
-    ...mapState(['selectedStudy', 'searchModalSearch']),
+    ...mapState(['selectedStudy', 'searchModalSearch', 'linkingTargets']),
     ...mapGetters(['userToken']),
     /**
      * Returns the current page postion for files table in pagination ticker
@@ -204,6 +206,12 @@ export default {
         this.$emit('reset-search-params')
       }
     },
+    linkingTargets: {
+      handler: async function(targets) {
+        this.selections = targets
+      },
+      immediate: true
+    }
   },
   methods: {
     ...mapActions(['updateSearchModalVisible', 'updateSearchModalSearch', 'setLinkingTargets']),
@@ -243,18 +251,8 @@ export default {
       this.updateSearchModalSearch(newSearch)
       await this.fetchRecords()
     },
-    onLinkingTargetsChanged: function(records) {
-      /*
-      // Set the target when record is clicked
-      var vis_arr_len = this.shadedVisits;
-      var samp_arr_len - this.shadedVisits;
-      //if a single selection has been made for sample or visit via user click, then they need to unselect it before proceeding
-      if (vis_arr_len.length == 1 || samp_arr_len.length == 1){
-        var to_be_linked = this.selectedRecord.details.id //CONFIRM THIS IS THE DATA WE ARE INTERESTED IN!
-        this.setLinkingTargets(to_be_linked)
-      }
-      */
-      this.setLinkingTargets(records)
+    updateLinkingTargets: function() {
+      this.setLinkingTargets(this.selections)
       this.updateSearchModalVisible(false)
     },
     onSelectionChanged: function(rows) {
@@ -339,5 +337,9 @@ h3 {
 }
 .download-icon {
   margin-top: -4px;
+}
+.linking-targets-button {
+  float: right;
+  margin-top: 1rem;
 }
 </style>

--- a/src/components/shared/IhHeader.vue
+++ b/src/components/shared/IhHeader.vue
@@ -62,7 +62,6 @@ export default {
   padding-right: 20px;
   position: relative;
   width: 100%;
-  min-width: fit-content;
   justify-content: space-between;
 }
 .logo {

--- a/src/components/shared/IhSubheader.vue
+++ b/src/components/shared/IhSubheader.vue
@@ -51,7 +51,6 @@ export default {
   display: flex;
   background-color: $purple_2;
   width: 100%;
-  min-width: fit-content;
   background-color: rgba(189, 189, 189, .1);
   font-weight: 400;
   padding: 1rem 1rem;
@@ -59,11 +58,9 @@ export default {
 }
 .text-container {
   color: black;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
   margin-right: 1rem;
-  display: flex;
+  display: contents;
+  width: -webkit-fill-available;
 }
 .text-container:hover {
   cursor: default;
@@ -75,7 +72,11 @@ export default {
   }
 }
 .route-info {
+  width: 100%;
   display: flex;
+  white-space: nowrap;
+  text-overflow: clip;
+  overflow: hidden;
 }
 .back-navigation-container {
   margin-right: 1rem;

--- a/src/components/shared/PaginationPageMenu/PaginationPageMenu.vue
+++ b/src/components/shared/PaginationPageMenu/PaginationPageMenu.vue
@@ -51,12 +51,13 @@ export default {
     },
     pageSize: {
       type: Number,
-      default: 25
+      default: 10
     },
     pageSizeOptions: {
       type: Array,
       default: () => {
         return [
+          10,
           25,
           50,
           100

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -107,7 +107,7 @@ const store = new Vuex.Store({
       isModelInvalid: false,
       filters: [],
       model: '',
-      limit: 25,
+      limit: 10,
       offset: 0
     },
     scientificUnits: [],

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -129,7 +129,7 @@ const store = new Vuex.Store({
       userId: DATASET_ACTIVITY_ALL_CONTRIBUTORS //MIGHT NEED TO CHANGE THIS
     },
     */
-    linkingTarget: {},
+    linkingTargets: [],
     searchPage: '',
     shadedParticipants: [],
     shadedVisits: [],
@@ -213,8 +213,8 @@ const store = new Vuex.Store({
     triggerForClearing (state){
       return state.triggerForClearing
     },
-    linkingTarget (state) {
-      return state.linkingTarget
+    linkingTargets (state) {
+      return state.linkingTargets
     },
     datasetNodeId(state) {
       return state.datasetNodeId
@@ -314,8 +314,8 @@ const store = new Vuex.Store({
     SET_SEARCH_PAGE (state, data) {
       state.searchPage = data
     },
-    SET_LINKING_TARGET (state, data) {
-      state.linkingTarget = data
+    SET_LINKING_TARGETS (state, data) {
+      state.linkingTargets = data
     },
     CLEAR_CLICKED_SELECTIONS (state){
       state.shadedParticipants = []
@@ -495,8 +495,8 @@ const store = new Vuex.Store({
     setSearchPage({ commit }, data) {
       commit('SET_SEARCH_PAGE', data)
     },
-    setLinkingTarget({ commit }, data) {
-      commit('SET_LINKING_TARGET', data)
+    setLinkingTargets({ commit }, data) {
+      commit('SET_LINKING_TARGETS', data)
     },
     async setScientificUnits ({ commit }) {
       const apiKey = this.state.profile.token

--- a/src/views/FileUpload.vue
+++ b/src/views/FileUpload.vue
@@ -59,7 +59,7 @@
       <h2></h2>
       <template v-if="!isLinkingTargetSet">
         <bf-button v-on:click="updateSearchModalVisible(true)">
-          Select Linking Target
+          Select Linking Targets
         </bf-button>
       </template>
       <template v-else>
@@ -163,9 +163,9 @@ export default {
   ],
   computed: {
     ...mapGetters(['allStudies', 'selectedStudyName','userToken','uploadDestination','datasetId','getRelationshipTypeByName']),
-  ...mapState(['linkingTarget']),
+  ...mapState(['linkingTargets']),
   isLinkingTargetSet() {
-    return !isEmpty(this.linkingTarget)
+    return !isEmpty(this.linkingTargets)
   },
     //returns true if more than 1 select file
     multipleSelected: function () {
@@ -309,7 +309,7 @@ export default {
         var i = f.content.id
         selecteditemids.push(i)
       }
-      //NOTE: verify linkingTargetS  var
+      //NOTE: verify linkingTargets  var
       var iter2 = this.linkingTargets;
       //iterating through linking target(s). We then map all of the selected files (i.e. link) to the current target
       for (const j of iter2){

--- a/src/views/FileUpload.vue
+++ b/src/views/FileUpload.vue
@@ -7,43 +7,48 @@
       <ih-subheader previousRoute="/studies">
         <template slot="text">
           <template v-if="!isLinkingTargetSet">No Linking Target(s) Selected</template>
-           <!--if visit is selected-->
-          <template v-else-if="linkingTarget.modelId === '9c579bef-6ce0-4632-be1c-a95aadc982c4'">
-            Linking Target:
-            <div class="ml-16">
-              <div class="property-text">
-                Visit Event ID
-              </div>
-              <div>
-                {{linkingTarget.visit_event}}
-              </div>
-            </div>
-            <div class="ml-16">
-              <div class="property-text">
-                Event Name
-              </div>
-              <div>
-                {{linkingTarget.event_name}}
-              </div>
-            </div>
-          </template>
-           <!--if sample is selected-->
-          <template v-else-if="linkingTarget.modelId === 'e1ada387-5401-4409-b9d6-748f3aaddf23'">
-            Linking Target:
-            <div class="ml-16">
-              <div class="property-text">
-                Sample Type ID
-              </div>
-              <div>
-                {{linkingTarget.sample_type_id}}
-              </div>
-            </div>
-            <div class="ml-16">
-              <div class="property-text">
-                Study Sample ID
-              </div>
-              <div>
-                {{linkingTarget.study_sample_id}}
+          <template v-else>
+            Linking Target(s):
+            <div class="targets-container">
+              <div class="target-item" v-for="(target, index) in linkingTargets" :key="index">
+                <!--if visit is selected-->
+                <template v-if="target.modelId === '9c579bef-6ce0-4632-be1c-a95aadc982c4'">
+                  <div class="ml-16" >
+                    <div class="property-text">
+                      Visit Event ID
+                    </div>
+                    <div>
+                      {{target.visit_event}}
+                    </div>
+                  </div>
+                  <div class="ml-16">
+                    <div class="property-text">
+                      Event Name
+                    </div>
+                    <div>
+                      {{target.event_name}}
+                    </div>
+                  </div>
+                </template>
+                <!--if sample is selected-->
+                <template v-else-if="target.modelId === 'e1ada387-5401-4409-b9d6-748f3aaddf23'">
+                  <div class="ml-16">
+                    <div class="property-text">
+                      Sample Type ID
+                    </div>
+                    <div>
+                      {{target.sample_type_id}}
+                    </div>
+                  </div>
+                  <div class="ml-16">
+                    <div class="property-text">
+                      Study Sample ID
+                    </div>
+                    <div>
+                      {{target.study_sample_id}}
+                    </div>
+                  </div>
+                </template>
               </div>
             </div>
           </template>
@@ -64,7 +69,7 @@
       </template>
       <template v-else>
       <bf-button v-on:click="updateSearchModalVisible(true)">
-        Change Linking Target
+        Select Linking Targets
       </bf-button>
       </template>
       <div class="logo-container">
@@ -163,10 +168,10 @@ export default {
   ],
   computed: {
     ...mapGetters(['allStudies', 'selectedStudyName','userToken','uploadDestination','datasetId','getRelationshipTypeByName']),
-  ...mapState(['linkingTargets']),
-  isLinkingTargetSet() {
-    return !isEmpty(this.linkingTargets)
-  },
+    ...mapState(['linkingTargets']),
+    isLinkingTargetSet() {
+      return !isEmpty(this.linkingTargets)
+    },
     //returns true if more than 1 select file
     multipleSelected: function () {
       return this.selectedFiles.length > 1
@@ -668,15 +673,27 @@ export default {
 <style scoped lang="scss">
 @import '@/assets/css/_variables.scss';
 .sidebar-container {
-  width: auto;
-  min-width: 10rem;
-  max-width: 20rem;
+  width: 20%;
 }
 .selected-content-container {
-  flex-grow: 1;
+  width: 80%;
 }
 .container {
   display: flex;
+}
+.target-item {
+  display: inline-block;
+  border-right: 1px solid orange;
+  padding-right: 1rem;
+}
+.targets-container .target-item:last-child {
+  border-right: none;
+}
+.targets-container {
+  white-space: nowrap;
+  overflow: auto;
+  width: -webkit-fill-available;
+  margin-right: 1rem;
 }
 .logo-container {
   gap: 5px;
@@ -696,6 +713,7 @@ export default {
     //padding: 0 2rem;
     color: #2f26ad;
   }
+}
 .property-text {
   color: $app-primary-color;
   font-size: 1rem;
@@ -703,6 +721,5 @@ export default {
 }
 ::v-deep .text-container {
   align-items: flex-end;
-}
 }
 </style>


### PR DESCRIPTION
-Updated the store property linkingTarget to be an array of objects instead of a singular object

-Updated the RecordsTable to allow for multiple selections while persisting selections between pages